### PR TITLE
Update lint workflow trigger logic

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: lint
 
-on: ["push", "pull_request"]
+on: # Rebuild any PRs and main branch changes
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
## Description

Fixes linter workflow to _only_ trigger on pull request events and pushes to the `main` branch, thus avoiding duplicate CI runs when pushing commits to a PR branch.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)