### PR TITLE
Fix README badge URLs and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Open Source Project Template
 
-[![Release](https://img.shields.io/github/v/release/wayfair/ospo-automation?display_name=tag)](CHANGELOG.md)
-[![Lint](https://github.com/wayfair/ospo-automation/actions/workflows/markdown.yml/badge.svg?branch=main)](https://github.com/wayfair/ospo-automation/actions/workflows/lint.yml)
+[![Release](https://img.shields.io/badge/release-v0.0.1-blue.svg)](CHANGELOG.md)
+[![Lint](https://github.com/wayfair/ospo-automation/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/wayfair/ospo-automation/actions/workflows/lint.yml)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Maintainer](https://img.shields.io/badge/Maintainer-Wayfair-7F187F)](https://wayfair.github.io)
 


### PR DESCRIPTION
## Description

### Fixed

Corrects the following README badge URLs:
- Release version tag
- Markdown lint workflow

### Changed

Updates the Release badge to hardcode the version tag in markdown. Until this repository is made public, we won't be able to leverage the Shields API, which relies upon reading public repository release data to generate tags dynamically.