### PR TITLE
Update workflow to use v3 of auto-approve action

### DIFF
--- a/.github/workflows/fork.yml
+++ b/.github/workflows/fork.yml
@@ -45,12 +45,10 @@ jobs:
             })
       - name: ✅ approve PR
         if: ${{ success() }}
-        # Using contribs fork to make action compliant with migration to node v16
-        uses: wayfair-contribs/auto-approve-action@update-actions-runner-node
+        uses: hmarr/auto-approve-action@v3
         with:
           github-token: ${{ secrets.OSPO_API_TOKEN }}
       - name: 🚀 create fork
-        # Using forker release which sets output value for forkUrl
         uses: wayfair-incubator/forker@v0.0.6
         with:
           token: ${{ secrets.OSPO_API_TOKEN }}


### PR DESCRIPTION
## Description

I contributed https://github.com/hmarr/auto-approve-action/pull/205 to avoid [deprecation errors](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) when running `node12` actions. 

The fix was recently accepted by the maintainer, with a new `v3` action release cut, so we should use that rather than my `wayfair-contribs` branch.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wayfair/ospo-automation/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
