### PR TITLE
Creating default preset for Renovate configuration

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate configuration recommended by the Wayfair OSPO",
+  "labels": [
+    "renovate/{{depName}}"
+  ],
+  "extends": [
+    "config:base",
+    ":rebaseStalePrs",
+    "group:linters",
+    "group:allNonMajor",
+    "schedule:earlyMondays",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "platformAutomerge": true,
+  "rebaseWhen": "behind-base-branch",
+  "packageRules": [{
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchCurrentVersion": "!/^0/",
+      "groupName": "🛠 Minor Updates",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "✅ GitHub Actions",
+      "automerge": true
+    }
+  ]
+}

--- a/default.json
+++ b/default.json
@@ -9,20 +9,15 @@
     ":rebaseStalePrs",
     "group:linters",
     "group:allNonMajor",
-    "schedule:earlyMondays",
-    "helpers:pinGitHubActionDigests"
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
+    "schedule:earlyMondays"
   ],
   "platformAutomerge": true,
   "rebaseWhen": "behind-base-branch",
   "packageRules": [{
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchCurrentVersion": "!/^0/",
-      "groupName": "🛠 Minor Updates",
-      "automerge": true
-    },
-    {
       "matchManagers": ["github-actions"],
-      "groupName": "✅ GitHub Actions",
+      "groupName": "GitHub Actions",
       "automerge": true
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,24 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Renovate configuration recommended by the Wayfair OSPO",
-  "labels": [
-    "renovate/{{depName}}"
-  ],
+  "description": "Wayfair's preset configuration for Renovate",
   "extends": [
-    "config:base",
-    "schedule:earlyMondays",
-    ":rebaseStalePrs"
-  ],
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchCurrentVersion": "!/^0/",
-      "groupName": "Minor Updates",
-      "automerge": true
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
-    }
+    "github>wayfair/ospo-automation"
   ]
 }


### PR DESCRIPTION
## Description

We'd like to shift towards a model where the `ospo-automation` repository serves as the source of truth for storing our recommended base Renovate configuration for all of Wayfair's open source projects, including the `oss-template`. This change introduces a new `default.json` preset configuration for Renovate, which we can then inherit in `renovate.json` configuration files, including in this very repository.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
